### PR TITLE
Fix for escrow race condition

### DIFF
--- a/bob2k14/mdb_server/src/server.ts
+++ b/bob2k14/mdb_server/src/server.ts
@@ -237,27 +237,24 @@ class mdb_server {
                                     clearTimeout(mdb.solicit_tm);
                                     cb_temp(null, mdb.last_buffer);
                                 }
+                                if (mdb.last_buffer[0] != "X")
+                                {
+                                //send to the remote endpoint.
+                                mdb.rpc_client.request("Soda.remotemdb", [mdb.last_buffer], function (err, response)
+                                        {
+                                            if (err)
+                                            {
+                                                log.error("Error contacting remote endpoint", err);
+                                            }
+                                            else
+                                            {
+                                                log.debug("remotemdb successful, response=", response);
+                                            }
+                                        });
+                                }
                                 else
                                 {
-                                    if (mdb.last_buffer[0] != "X")
-                                    {
-                                    //otherwise send to the remote endpoint.
-                                    mdb.rpc_client.request("Soda.remotemdb", [mdb.last_buffer], function (err, response)
-                                            {
-                                                if (err)
-                                                {
-                                                    log.error("Error contacting remote endpoint", err);
-                                                }
-                                                else
-                                                {
-                                                    log.debug("remotemdb successful, response=", response);
-                                                }
-                                            });
-                                    }
-                                    else
-                                    {
-                                        log.trace("Error ignored: " + mdb.last_buffer);
-                                    }
+                                    log.trace("Error ignored: " + mdb.last_buffer);
                                 }
                             }
                         });


### PR DESCRIPTION
Fixes #68. Note that callbacks for mdb/p115 server requests are all empty, and the response message "Z" is just logged as unrecognized in the soda server.