### PR TITLE
Fix price list tablesorter

### DIFF
--- a/django/chezbob/util/pricing.py
+++ b/django/chezbob/util/pricing.py
@@ -90,7 +90,7 @@ def update_price_listing(out, update=True):
 // <![CDATA[
 $(document).ready(function() {
   $(".tablesorter").tablesorter();
-}
+})
 // ]]>
 </script>
 """)


### PR DESCRIPTION
It looks like a missing parenthesis prevented loading the ability to sort the table by clicking the headings.