### PR TITLE
Fix ui top bar balance warning

### DIFF
--- a/bob2k14/soda_server/ui_src/kiosk.html
+++ b/bob2k14/soda_server/ui_src/kiosk.html
@@ -20,7 +20,6 @@
                 <li id="balancepanel" class="hidden"><a><i class="fa fa-money"></i> <i class="fa fa-warning hidden" id="balancewarn">⚠️</i> Balance <i class="fa fa-dollar"></i><span class="balance"></span></a></li>
                 <li id="loginpanel" class="hidden"><a><i class="fa fa-user"></i> Logged in as <span class="username"></span></a></li>
                 <li class="hidden" id="logout"><a href="#" id="logoutbtn">Logout</a></li>
-                </li>
             </ul>
         </div>
         <div class="background-image" id="carousel"></div>

--- a/bob2k14/soda_server/ui_src/kiosk.html
+++ b/bob2k14/soda_server/ui_src/kiosk.html
@@ -17,7 +17,7 @@
             </div>
             <ul class="nav pull-right navbar-nav">
                 <li id="timeoutpanel" class="hidden"><a><i class="fa fa-clock-o"></i> Timeout in <span id="timeout"> s</span></a></li>
-                <li id="balancepanel" class="hidden"><a><i class="fa fa-money"></i> <i class="fa fa-warning hidden" id="balancewarn"></i> Balance <i class="fa fa-dollar"></i><span class="balance"></span></a></li>
+                <li id="balancepanel" class="hidden"><a><i class="fa fa-money"></i> <i class="fa fa-warning hidden" id="balancewarn">⚠️</i> Balance <i class="fa fa-dollar"></i><span class="balance"></span></a></li>
                 <li id="loginpanel" class="hidden"><a><i class="fa fa-user"></i> Logged in as <span class="username"></span></a></li>
                 <li class="hidden" id="logout"><a href="#" id="logoutbtn">Logout</a></li>
                 </li>


### PR DESCRIPTION
The negative balance warning is misplaced when its root is empty. Let's put in a ⚠️.