### PR TITLE
Delay showing the balance warning tooltip while the page loads.

### DIFF
--- a/bob2k14/soda_server/ui_src/client.ts
+++ b/bob2k14/soda_server/ui_src/client.ts
@@ -237,7 +237,9 @@ export class Client
         {
             $("#balancepanel a").css('color', '#ff0000');
             $("#balancewarn").removeClass('hidden');
-            $("#balancewarn").tooltip('show');
+            setTimeout(function() {
+                $("#balancewarn").tooltip('show')
+            }, 500);
             setTimeout(function() {
                 $("#balancewarn").tooltip('hide')
             }, 3000);

--- a/bob2k14/soda_server/ui_src/kiosk.html
+++ b/bob2k14/soda_server/ui_src/kiosk.html
@@ -17,7 +17,7 @@
             </div>
             <ul class="nav pull-right navbar-nav">
                 <li id="timeoutpanel" class="hidden"><a><i class="fa fa-clock-o"></i> Timeout in <span id="timeout"> s</span></a></li>
-                <li id="balancepanel" class="hidden"><a><i class="fa fa-money"></i> <i class="fa fa-warning hidden" id="balancewarn">⚠️</i> Balance <i class="fa fa-dollar"></i><span class="balance"></span></a></li>
+                <li id="balancepanel" class="hidden"><a><i class="fa fa-money"></i> <i class="fa fa-warning hidden" id="balancewarn"></i> Balance <i class="fa fa-dollar"></i><span class="balance"></span></a></li>
                 <li id="loginpanel" class="hidden"><a><i class="fa fa-user"></i> Logged in as <span class="username"></span></a></li>
                 <li class="hidden" id="logout"><a href="#" id="logoutbtn">Logout</a></li>
             </ul>


### PR DESCRIPTION
Because things can't be as simple as they seem. This also reverts the previous non-functional fix.